### PR TITLE
Add a missing exec_depend on rmw_dds_common

### DIFF
--- a/rmw_connext_shared_cpp/package.xml
+++ b/rmw_connext_shared_cpp/package.xml
@@ -22,6 +22,8 @@
   <build_depend>rmw_dds_common</build_depend>
   <build_depend>rti-connext-dds-5.3.1</build_depend>
 
+  <exec_depend>rmw_dds_common</exec_depend>
+
   <build_export_depend>connext_cmake_module</build_export_depend>
   <build_export_depend>rti-connext-dds-5.3.1</build_export_depend>
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
